### PR TITLE
allow test and dev secret keys to be saved to repo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,3 @@
-dependencies:
-  post:
-    - cp config/secrets.yml.example config/secrets.yml
 test:
   override:
     - bundle exec rspec

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,7 +11,7 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base:
+  secret_key_base: b11e9897389447ff05fd7bbdea7bc24ba5c7991fe74c4f3f88408db1c5be30d4b651134c5859de49a1cebde59f986d0c1e24fd47cb195833fdfe334a535f74cb
 
 test:
   secret_key_base: 3ae05ded2971a683e1b784bd38f93d38e82744b502ba566e4f3ca197accf6adb2763a63f86227ad09bfe58d3fc61d36576bdcf6f083237e8a104313d68a1bfb4


### PR DESCRIPTION
heroku needs the file and we can't easily copy a file up there. production key is not saved
